### PR TITLE
Fixes failing tests in record.py and dublincore.py

### DIFF
--- a/tests/dublincore.py
+++ b/tests/dublincore.py
@@ -1,10 +1,14 @@
 import unittest
+
 from rdflib import ConjunctiveGraph
-from pyuntl.untldoc import untldict2py, untlpy2dcpy, \
-    untlpydict2dcformatteddict, generate_dc_xml, generate_dc_json, \
-    generate_dc_txt, dcdict2rdfpy
+from lxml import objectify
+
+from pyuntl.dc_structure import DC, DC_NAMESPACES
+from pyuntl.untldoc import (untldict2py, untlpy2dcpy,
+                            untlpydict2dcformatteddict,
+                            generate_dc_xml, generate_dc_json,
+                            generate_dc_txt, dcdict2rdfpy)
 from tests import UNTL_DICT, DUBLIN_CORE_XML
-from pyuntl.dc_structure import DC
 try:
     # the json module was included in the stdlib in python 2.6
     # http://docs.python.org/library/json.html
@@ -19,11 +23,11 @@ except ImportError:
 
 class DublinCoreTest(unittest.TestCase):
     def setUp(self):
-        """ Used to setup the initial data """
+        """Set up the initial data."""
         self.root_element = untlpy2dcpy(untldict2py(UNTL_DICT))
 
     def testDCJSON(self):
-        '''test output and re-jsoning of json export'''
+        """Test output and re-JSONing of JSON export."""
         dcjson = generate_dc_json(UNTL_DICT.copy())
         j = json.loads(dcjson)
         self.assertTrue(type(j), dict)
@@ -32,22 +36,59 @@ class DublinCoreTest(unittest.TestCase):
                             % (key, UNTL_DICT))
 
     def testDCtoRDF(self):
-        '''test dublin core to RDF function'''
+        """Test Dublin Core to RDF function."""
         rdf = dcdict2rdfpy(UNTL_DICT)
         self.assertEqual(type(rdf), ConjunctiveGraph)
 
     def testDCText(self):
-        '''test that we can generate a dc text'''
+        """Test that we can generate a dc text."""
         dctext = generate_dc_txt(UNTL_DICT)
         self.assertEqual(type(dctext), str)
 
-    def testDCxml(self):
-        '''render valid dublin core xml test'''
-        dxml = generate_dc_xml(UNTL_DICT)
-        self.assertEqual(dxml.strip(), DUBLIN_CORE_XML.strip())
+    def testDCXMLRootElement(self):
+        """Check the Dublin Core for expected attrib and nsmap on root."""
+        generated_dxml = generate_dc_xml(UNTL_DICT)
+
+        # Verify root element has expected attribs, nsmap, and tag.
+        generated_dxml_root = objectify.fromstring(generated_dxml)
+
+        schema_location = ('http://www.openarchives.org/OAI/2.0/oai_dc/ '
+                           'http://www.openarchives.org/OAI/2.0/oai_dc.xsd')
+        expected_tag = '{http://www.openarchives.org/OAI/2.0/oai_dc/}dc'
+
+        self.assertTrue(schema_location in generated_dxml_root.attrib.values())
+        self.assertEqual(generated_dxml_root.nsmap, DC_NAMESPACES)
+        self.assertEqual(generated_dxml_root.tag, expected_tag)
+
+    def testDCXMLNonRootElements(self):
+        """Test for expected Dublin Core elements."""
+        generated_dxml = generate_dc_xml(UNTL_DICT)
+
+        generated_dxml_root = objectify.fromstring(generated_dxml)
+        constant_dxml_root = objectify.fromstring(DUBLIN_CORE_XML)
+        results = []
+        # Check if each of the root's children from the generated XML
+        # has a match in the string constant's XML.
+        for child in generated_dxml_root.iterchildren():
+            # For each child, get all of the children with the same tag
+            # from the XML being compared.
+            same_tag_list = constant_dxml_root.findall(child.tag)
+            element_found = False
+            child_children = len(child.getchildren())
+            # Check if any of the possible elements are a match.
+            for current in same_tag_list:
+                if (current.text == child.text and
+                        current.tail == child.tail and
+                        current.attrib == child.attrib and
+                        len(current.getchildren()) == child_children):
+                    element_found = True
+                    break
+            results.append(element_found)
+        # If all elements came up with a match. Let it be True.
+        self.assertTrue(all(results))
 
     def testDCFormattedDict(self):
-        '''make sure we can format to dc dict properly'''
+        """Verify we can format to dc dict properly."""
         # make the dictionary
         dcd = untlpydict2dcformatteddict(UNTL_DICT)
         # workaround to make usable in python 2.5
@@ -56,91 +97,88 @@ class DublinCoreTest(unittest.TestCase):
         self.assertTrue(len(dcd) < len(UNTL_DICT))
 
     def testConversionFromUNTLPY(self):
-        '''confirms the conversion from untl py object in setup worked right'''
+        """Verify the conversion from untl object."""
         self.assertTrue(type(self.root_element) is DC)
 
     def testDoesNotCreateContributor(self):
-        """Test to make sure there is no contributor element (not in dublin)"""
+        """Verify there is no contributor element (not in Dublin Core)."""
         for element in self.root_element.children:
             self.assertNotEqual(element.tag, 'contributor')
 
     def testCreatesSource(self):
-        """Test to make sure the the source's children are added"""
+        """Verify the source's children are added."""
         for element in self.root_element.children:
             if element.tag == 'source':
                 self.assertNotEqual(len(element.children), 0)
 
     def testCreatesRelation(self):
-        """Test to make sure the the relation's children are added"""
+        """Verify the relation's children are added."""
         for element in self.root_element.children:
             if element.tag == 'relation':
                 self.assertNotEqual(len(element.children), 0)
 
     def testCreatesRights(self):
-        """Test to make sure the the rights's children are added"""
+        """Verify the rights' children are added."""
         for element in self.root_element.children:
             if element.tag == 'rights':
                 self.assertNotEqual(len(element.children), 0)
 
     def testCreatesType(self):
-        """
-           Test to make sure the the type element
-           is created but not populated
-        """
+        """Verify the type element is created but not populated."""
         for element in self.root_element.children:
             if element.tag == 'type':
                 self.assertNotEqual(len(element.content), 0)
 
     def testCreatesPublisher(self):
-        """Test to make sure the the publisher's children are added"""
+        """Verify the publisher's children are added."""
         for element in self.root_element.children:
             if element.tag == 'publisher':
                 self.assertNotEqual(len(element.content), 0)
 
     def testCreatesDescription(self):
-        """test add description"""
+        """Verify the description is added."""
         for element in self.root_element.children:
             if element.tag == 'description' and len(element.children) == 0:
-                self.assertNotEqual((element.content), None)
+                self.assertTrue(element.content is not None)
 
     def testCreatesFormat(self):
-        """test add format"""
+        """Verify the format is added."""
         for element in self.root_element.children:
             if element.tag == 'format' and len(element.children) == 0:
-                self.assertNotEqual((element.content), None)
+                self.assertTrue(element.content is not None)
 
     def testCreatesTitle(self):
-        """test add title"""
+        """Verify the title is added."""
         for element in self.root_element.children:
             if element.tag == 'title' and len(element.children) == 0:
-                self.assertNotEqual((element.content), None)
+                self.assertTrue(element.content is not None)
 
     def testCreatesCoverage(self):
-        """test create coverage"""
+        """Verify the coverage is added."""
         for element in self.root_element.children:
             if element.tag == 'coverage' and len(element.children) == 0:
-                self.assertNotEqual((element.content), None)
+                self.assertTrue(element.content is not None)
 
     def testCreatesDate(self):
-        """test create date"""
+        """Verify the date is added."""
         for element in self.root_element.children:
             if element.tag == 'date' and len(element.children) == 0:
-                self.assertNotEqual((element.content), None)
+                self.assertTrue(element.content is not None)
 
     def testCreatesIdentifier(self):
-        """make sure identifier is added"""
+        """Verify the identifier is added."""
         for element in self.root_element.children:
             if element.tag == 'identifier' and len(element.children) == 0:
-                self.assertNotEqual((element.content), None)
+                self.assertTrue(element.content is not None)
 
     def testCreatesSubject(self):
-        """make sure subject is created"""
+        """Verify the subject is created."""
         for element in self.root_element.children:
             if element.tag == 'subject' and len(element.children) == 0:
-                self.assertNotEqual((element.content), None)
+                self.assertTrue(element.content is not None)
 
     def testCreatesCreator(self):
-        """create creator but not children"""
+        """Test the creator element."""
         for element in self.root_element.children:
             if element.tag == 'creator':
                 self.assertNotEqual(len(element.content), 0)

--- a/tests/record.py
+++ b/tests/record.py
@@ -159,7 +159,7 @@ class RecordTest(unittest.TestCase):
         # Get ordered list of children tags.
         tag_list = [UNTL_PTH_ORDER.index(elem.tag) for elem in c2.children]
         # Verify order is in order of UNTL_PTH_ORDER.
-        self.assertTrue(all(tag_list[i] <= tag_list[i+1] for i in xrange(len(tag_list)-1)))
+        self.assertTrue(all(current <= next_ for current, next_ in zip(tag_list, tag_list[1:])))
 
     def test_validate(self):
         # this method was left undeveloped in pyuntl untl_structure

--- a/tests/record.py
+++ b/tests/record.py
@@ -154,15 +154,12 @@ class RecordTest(unittest.TestCase):
         self.assertTrue(d1 == d2)
 
     def test_sort_untl(self):
-        c1 = untldict2py(UNTL_DICT)
         c2 = untldict2py(UNTL_DICT)
         c2.sort_untl(UNTL_PTH_ORDER)
-        # make sure the sort of the children elements changes
-        self.assertTrue(
-            c1.children[0].tag != c2.children[0].tag and
-            c2.children[0].tag == 'title' and
-            c1.children[0].tag == 'publisher'
-        )
+        # Get ordered list of children tags.
+        tag_list = [UNTL_PTH_ORDER.index(elem.tag) for elem in c2.children]
+        # Verify order is in order of UNTL_PTH_ORDER.
+        self.assertTrue(all(tag_list[i] <= tag_list[i+1] for i in xrange(len(tag_list)-1)))
 
     def test_validate(self):
         # this method was left undeveloped in pyuntl untl_structure


### PR DESCRIPTION
Fixes failing tests in record.py and dublincore.py related to expectation that XML element attributes and children will be in consistent order. Includes some pep8 clean up in dublincore.py. Further pep8 cleanup for pyuntl should be in different PR. Will fix #2.