### PR TITLE
Allow flexible scheme in identifier URLs via identifier_director.

### DIFF
--- a/pyuntl/dc_structure.py
+++ b/pyuntl/dc_structure.py
@@ -248,6 +248,8 @@ def identifier_director(**kwargs):
     """Direct how to handle the identifier element."""
     ark = kwargs.get('ark', None)
     domain_name = kwargs.get('domain_name', None)
+    # Set default scheme if it is None or is not supplied.
+    scheme = kwargs.get('scheme') or 'http'
     qualifier = kwargs.get('qualifier', None)
     content = kwargs.get('content', '')
     # See if the ark and domain name were given.
@@ -257,7 +259,7 @@ def identifier_director(**kwargs):
         # Create the permalink URL.
         if not domain_name.endswith('/'):
             domain_name += '/'
-        permalink_url = 'http://' + domain_name + ark
+        permalink_url = '%s://%s%s' % (scheme, domain_name, ark)
         # Make sure it has a trailing slash.
         if not permalink_url.endswith('/'):
             permalink_url += '/'

--- a/pyuntl/untldoc.py
+++ b/pyuntl/untldoc.py
@@ -293,6 +293,7 @@ def untlpy2dcpy(untl_elements, **kwargs):
     eDate = None
     ark = kwargs.get('ark', None)
     domain_name = kwargs.get('domain_name', None)
+    scheme = kwargs.get('scheme', 'http')
     resolve_values = kwargs.get('resolve_values', None)
     resolve_urls = kwargs.get('resolve_urls', None)
     verbose_vocabularies = kwargs.get('verbose_vocabularies', None)
@@ -349,6 +350,7 @@ def untlpy2dcpy(untl_elements, **kwargs):
             qualifier='permalink',
             domain_name=domain_name,
             ark=ark,
+            scheme=scheme
         )
         dc_root.add_child(permalink_identifier)
         # Create and add the ark identifier.
@@ -419,6 +421,7 @@ def untlpydict2dcformatteddict(untl_dict, **kwargs):
     """Convert a UNTL data dictionary to a formatted DC data dictionary."""
     ark = kwargs.get('ark', None)
     domain_name = kwargs.get('domain_name', None)
+    scheme = kwargs.get('scheme', 'http')
     resolve_values = kwargs.get('resolve_values', None)
     resolve_urls = kwargs.get('resolve_urls', None)
     verbose_vocabularies = kwargs.get('verbose_vocabularies', None)
@@ -432,6 +435,7 @@ def untlpydict2dcformatteddict(untl_dict, **kwargs):
         resolve_values=resolve_values,
         resolve_urls=resolve_urls,
         verbose_vocabularies=verbose_vocabularies,
+        scheme=scheme
     )
     # Return a formatted DC dictionary.
     return dcpy2formatteddcdict(dc_py)

--- a/tests/dublincore.py
+++ b/tests/dublincore.py
@@ -4,7 +4,7 @@ import unittest
 from rdflib import ConjunctiveGraph
 from lxml import objectify
 
-from pyuntl.dc_structure import DC, DC_NAMESPACES
+from pyuntl.dc_structure import DC, DC_NAMESPACES, identifier_director
 from pyuntl.untldoc import (untldict2py, untlpy2dcpy,
                             untlpydict2dcformatteddict,
                             generate_dc_xml, generate_dc_json,
@@ -86,6 +86,15 @@ class DublinCoreTest(unittest.TestCase):
         self.assertFalse('content' in dcd['publisher'], '%s not in %s'
                          % ('content', dcd['publisher']))
         self.assertTrue(len(dcd) < len(UNTL_DICT))
+
+    def testIdentifierDirectorHttpsScheme(self):
+        """Verify DC Identifier permalink gets https scheme."""
+        dc_element = identifier_director(ark='ark:/67531/test',
+                                         domain_name='example.com',
+                                         qualifier='permalink',
+                                         scheme='https')
+        self.assertEqual(dc_element.content,
+                         'https://example.com/ark:/67531/test/')
 
     def testConversionFromUNTLPY(self):
         """Verify the conversion from UNTL object."""


### PR DESCRIPTION
This should fix #11 by allowing a scheme to be passed for use.

@somexpert @jason-ellis @jthomale 