### PR TITLE
Fix #14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 python: 2.7
 env:
-    - TOX_ENV=py26
     - TOX_ENV=py27
     - TOX_ENV=flake8
 install:

--- a/pyuntl/dc_structure.py
+++ b/pyuntl/dc_structure.py
@@ -269,6 +269,7 @@ def identifier_director(**kwargs):
             content = '%s: %s' % (string.lower(qualifier), content)
     return DCIdentifier(content=content)
 
+
 DC_CONVERSION_DISPATCH = {
     'dc': DC,
     'coverage': DCCoverage,

--- a/pyuntl/etd_ms_structure.py
+++ b/pyuntl/etd_ms_structure.py
@@ -266,6 +266,7 @@ def subject_director(**kwargs):
     else:
         return ETD_MSSubject(content=kwargs.get('content'))
 
+
 ETD_MS_CONVERSION_DISPATCH = {
     'thesis': ETD_MS,
     'title': ETD_MSTitle,

--- a/pyuntl/form_logic.py
+++ b/pyuntl/form_logic.py
@@ -873,6 +873,7 @@ class Location(FormElement):
         self.view_type = 'inputbox'
         super(Location, self).__init__(**kwargs)
 
+
 UNTL_GROUP_DISPATCH = {
     'title': FormGroup,
     'identifier': FormGroup,

--- a/pyuntl/highwire_structure.py
+++ b/pyuntl/highwire_structure.py
@@ -267,6 +267,7 @@ def identifier_director(**kwargs):
     else:
         return None
 
+
 HIGHWIRE_CONVERSION_DISPATCH = {
     'title': CitationTitle,
     'creator': CitationAuthor,

--- a/pyuntl/metadata_generator.py
+++ b/pyuntl/metadata_generator.py
@@ -139,7 +139,7 @@ def pydict2xmlstring(metadata_dict, **kwargs):
                         element['content'],
                         attribs={'qualifier': element['qualifier']},
                         namespace=elements_namespace,
-                        )
+                    )
                 elif 'content' in element and 'role' in element:
                     create_dict_subelement(
                         root,

--- a/pyuntl/untl_structure.py
+++ b/pyuntl/untl_structure.py
@@ -204,7 +204,7 @@ class UNTLElement(object):
     def record_content_length(self):
         """Calculate length of record, excluding metadata."""
         untldict = py2dict(self)
-        del untldict['meta']
+        untldict.pop('meta', None)
         return len(str(untldict))
 
 

--- a/pyuntl/untldoc.py
+++ b/pyuntl/untldoc.py
@@ -228,8 +228,8 @@ def post2pydict(post, ignore_list):
                             child_list.append(
                                 PYUNTL_DISPATCH[attribute_tuple[j][0]](
                                     content=attribute_tuple[j][1][i]
-                                    )
                                 )
+                            )
             # Create the UNTL element.
             if content != '' and qualifier != '':
                 untl_element = PYUNTL_DISPATCH[element_tag](content=content,

--- a/pyuntl/util.py
+++ b/pyuntl/util.py
@@ -72,6 +72,7 @@ def untldict_normalizer(untl_dict, normalizations):
                                     elem_norms[qualifier](content)
     return untl_dict
 
+
 SUBJECT_NORMALIZERS = {
     'LCSH': normalize_LCSH,
     'UNTL-BS': normalize_UNTL,

--- a/runtests.py
+++ b/runtests.py
@@ -19,6 +19,7 @@ def suite():
     test_suite.addTest(dublincore.suite())
     return test_suite
 
+
 if __name__ == '__main__':
     runner = unittest.TextTestRunner()
     exit_code = not runner.run(suite()).wasSuccessful()

--- a/tests/dublincore.py
+++ b/tests/dublincore.py
@@ -188,5 +188,6 @@ def suite():
     test_suite = unittest.makeSuite(DublinCoreTest, 'test')
     return test_suite
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/etd.py
+++ b/tests/etd.py
@@ -70,5 +70,6 @@ def suite():
     test_suite = unittest.makeSuite(TestETD, 'test')
     return test_suite
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/field.py
+++ b/tests/field.py
@@ -59,7 +59,7 @@ class FieldTest(unittest.TestCase):
         """Test normalizing LCSH UNTL data."""
         normalize_required = {
             'subject': ['LCSH'],
-            }
+        }
         norm = untldict_normalizer(untl_dict, normalize_required)
         self.assertEqual(norm, normalized_dict)
 
@@ -68,7 +68,7 @@ class FieldTest(unittest.TestCase):
         """Test all the normalizations for UNTL."""
         normalize_required = {
             'subject': ['LCSH', 'UNTL-BS'],
-            }
+        }
         norm = untldict_normalizer(untl_dict, normalize_required)
         self.assertEqual(norm, normalized_dict)
 
@@ -76,6 +76,7 @@ class FieldTest(unittest.TestCase):
 def suite():
     test_suite = unittest.makeSuite(FieldTest, 'test')
     return test_suite
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/highwire.py
+++ b/tests/highwire.py
@@ -120,5 +120,6 @@ def suite():
     test_suite = unittest.makeSuite(TestHighwire, 'test')
     return test_suite
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/pyuntl_test.py
+++ b/tests/pyuntl_test.py
@@ -156,5 +156,6 @@ def suite():
     test_suite = unittest.makeSuite(TestUNTLDictionaryToPythonObject, 'test')
     return test_suite
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/reader.py
+++ b/tests/reader.py
@@ -59,5 +59,6 @@ def suite():
     test_suite = unittest.makeSuite(ReaderTest, 'test')
     return test_suite
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/record.py
+++ b/tests/record.py
@@ -176,5 +176,6 @@ def suite():
     test_suite = unittest.makeSuite(RecordTest, 'test')
     return test_suite
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/record.py
+++ b/tests/record.py
@@ -136,8 +136,6 @@ class RecordTest(unittest.TestCase):
     def test_record_content_length(self):
         field = PYUNTL_DISPATCH['title'](content='fake title')
         self.record.add_child(field)
-        field = PYUNTL_DISPATCH['meta'](content=None)
-        self.record.add_child(field)
         self.assertEquals(self.record.record_content_length, 38)
 
     def test_create_element_dict(self):

--- a/tests/writer.py
+++ b/tests/writer.py
@@ -35,5 +35,6 @@ def suite():
     test_suite = unittest.makeSuite(WriterTest, 'test')
     return test_suite
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ commands=python runtests.py
 [flake8]
 max-line-length = 99
 exclude = tests/__init__.py
+ignore = E722
 
 [testenv:flake8]
 deps=flake8


### PR DESCRIPTION
This prevents failure on getting a record_content_length when `<meta>` tags don't exist in a poorly formed metadata file. To fix #14.