### PR TITLE
Add untldoc tests

### DIFF
--- a/pyuntl/untldoc.py
+++ b/pyuntl/untldoc.py
@@ -10,6 +10,7 @@
 import json
 import re
 import urllib.request
+from copy import deepcopy
 from lxml.etree import iterparse
 from rdflib import Namespace, Literal, URIRef, ConjunctiveGraph
 
@@ -406,7 +407,7 @@ def untlpy2highwirepy(untl_elements, **kwargs):
                 # Otherwise, add the element to the list if it has content.
                 elif highwire_element.content:
                     highwire_list.append(highwire_element)
-        # If the title was found, add it to the list.
+    # If the title was found, add it to the list.
     if title:
         highwire_list.append(title)
     return highwire_list
@@ -456,6 +457,8 @@ def formatted_dc_dict(dc_dict):
     with a list of values for each element.
     i.e. {'publisher': ['someone', 'someone else'], 'title': ['a title'],}
     """
+    # Don't modify the unformatted dictionary in place.
+    dc_dict = deepcopy(dc_dict)
     for key, element_list in dc_dict.items():
         new_element_list = []
         # Add the content for each element to the new element list.

--- a/pyuntl/untldoc.py
+++ b/pyuntl/untldoc.py
@@ -44,9 +44,9 @@ class PyuntlException(Exception):
 def untlxml2py(untl_filename):
     """Parse a UNTL XML file object into a pyuntl element tree.
 
-    You can also pass this a string as file input like so:
+    You can also pass input like so:
     from io import BytesIO
-    untlxml2py(BytesIO(untl_string))
+    untlxml2py(BytesIO(untl_xml_bytes))
     """
     # Create a stack to hold parents.
     parent_stack = []
@@ -89,9 +89,9 @@ def untlxml2py(untl_filename):
 def untlxml2pydict(untl_filename):
     """Convert a UNTL XML file to a Python dictionary.
 
-    You can also pass this a string as file input like so:
+    You can also pass input like so:
     from io import BytesIO
-    untlxml2pydict(BytesIO(untl_string))
+    untlxml2pydict(BytesIO(untl_xml_bytes))
     """
     # Create a UNTL Python object from the XML file.
     untl_elements = untlxml2py(untl_filename)

--- a/pyuntl/untldoc.py
+++ b/pyuntl/untldoc.py
@@ -44,8 +44,8 @@ def untlxml2py(untl_filename):
     """Parse a UNTL XML file object into a pyuntl element tree.
 
     You can also pass this a string as file input like so:
-    import StringIO
-    untlxml2py(StringIO.StringIO(untl_string))
+    from io import BytesIO
+    untlxml2py(BytesIO(untl_string))
     """
     # Create a stack to hold parents.
     parent_stack = []
@@ -89,8 +89,8 @@ def untlxml2pydict(untl_filename):
     """Convert a UNTL XML file to a Python dictionary.
 
     You can also pass this a string as file input like so:
-    import StringIO
-    untlxml2pydict(StringIO.StringIO(untl_string))
+    from io import BytesIO
+    untlxml2pydict(BytesIO(untl_string))
     """
     # Create a UNTL Python object from the XML file.
     untl_elements = untlxml2py(untl_filename)

--- a/pyuntl/untldoc.py
+++ b/pyuntl/untldoc.py
@@ -703,11 +703,12 @@ def find_untl_errors(untl_dict, **kwargs):
     for element_name in REQUIRES_QUALIFIER:
         # Loop through the existing elements that require qualifers.
         for element in untl_dict.get(element_name, []):
-            error_dict[element_name] = 'no_qualifier'
-            # If it should be fixed, set an empty qualifier
-            # if it doesn't have one.
-            if fix_errors:
-                element.setdefault('qualifier', '')
+            # If there is no qualifier, record the error.
+            if not element.get('qualifier', None):
+                error_dict[element_name] = 'no_qualifier'
+                # If it should be fixed, set an empty qualifier.
+                if fix_errors:
+                    element.setdefault('qualifier', '')
     # Combine the error dict and UNTL dict into a dict.
     found_data = {
         'untl_dict': untl_dict,

--- a/pyuntl/untldoc.py
+++ b/pyuntl/untldoc.py
@@ -826,7 +826,7 @@ def etd_ms_dict2xmlfile(filename, metadata_dict):
     """Create an ETD MS XML file."""
     try:
         f = open(filename, 'w')
-        f.write(generate_etd_ms_xml(metadata_dict))
+        f.write(generate_etd_ms_xml(metadata_dict).decode('utf-8'))
         f.close()
     except:
         raise MetadataGeneratorException(

--- a/pyuntl/untldoc.py
+++ b/pyuntl/untldoc.py
@@ -159,9 +159,6 @@ def untldict2py(untl_dict):
                 untl_element = PYUNTL_DISPATCH[element_name](
                     content=content,
                 )
-            # Create element that only has children.
-            elif child_list:
-                untl_element = PYUNTL_DISPATCH[element_name]()
             # Add the UNTL element to the Python element list.
             untl_py_list.append(untl_element)
     # Add the UNTL elements to the root element.

--- a/tests/untldoc_test.py
+++ b/tests/untldoc_test.py
@@ -1,0 +1,299 @@
+import os
+from copy import deepcopy
+from io import BytesIO
+from unittest.mock import patch
+
+import pytest
+
+from pyuntl import untldoc, untl_structure as us, dc_structure as dc
+
+
+TEST_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)))
+
+UNTL_DICTIONARY = {'title': [{'qualifier': 'officialtitle',
+                              'content': 'Tres Actos'}],
+                   'creator': [{'qualifier': 'aut',
+                                'content': {'name': 'Last, Furston, 1807-1865.', 'type': 'per'}}],
+                   'publisher': [{'content': {'name': 'Fake Publishing'}}],
+                   'collection': [{'content': 'UNT'}],
+                   'date': [{'content': '1944',
+                             'qualifier': 'creation'}]}
+
+UNTL_STRING = ('<?xml version="1.0" encoding="UTF-8"?>\n'
+               '<metadata>\n'
+               '  <title qualifier="officialtitle">Tres Actos</title>\n'
+               '  <creator qualifier="aut">\n'
+               '    <name>Last, Furston, 1807-1865.</name>\n'
+               '    <type>per</type>\n'
+               '  </creator>\n'
+               '  <publisher>\n'
+               '    <name>Fake Publishing</name>\n'
+               '  </publisher>\n'
+               '  <date qualifier="creation">1944</date>\n'
+               '  <collection>UNT</collection>\n'
+               '</metadata>\n')
+
+
+def test_PyuntlException():
+    msg = 'Throw this'
+    try:
+        raise untldoc.PyuntlException(msg)
+    except untldoc.PyuntlException as err:
+        assert str(err) == msg
+
+
+def test_untlxml2py():
+    """Verify children are correctly added from the UNTL XML."""
+    xml = BytesIO(b'<?xml version="1.0" encoding="UTF-8"?>\n'
+                  b'<metadata>\n'
+                  b'  <title qualifier="officialtitle">Tres Actos</title>\n'
+                  b'  <creator qualifier="aut">\n'
+                  b'    <name>Last, Furston, 1807-1865.</name>\n'
+                  b'  </creator>\n'
+                  b'</metadata>\n')
+    root = untldoc.untlxml2py(xml)
+    assert isinstance(root, us.UNTLElement)
+    assert root.tag == 'metadata'
+    assert len(root.children) == 2
+    assert root.children[0].tag == 'title'
+    assert root.children[0].content == 'Tres Actos'
+    assert root.children[0].qualifier == 'officialtitle'
+    assert root.children[1].tag == 'creator'
+    assert root.children[1].qualifier == 'aut'
+    assert root.children[1].children[0].tag == 'name'
+    assert root.children[1].children[0].content == 'Last, Furston, 1807-1865.'
+
+
+def test_untlxml2py_namespace():
+    """Namespace is removed from element.tag when building py object.
+
+    Including xmlns in the xml prepends "{http://purl.org/dc/elements/1.1/}"
+    to element tags, but untlxml2py will ignore that.
+    """
+    xml = BytesIO(b'<?xml version="1.0" encoding="UTF-8"?>\n'
+                  b'<metadata xmlns="http://purl.org/dc/elements/1.1/">\n'
+                  b'  <title qualifier="officialtitle">Tres Actos</title>\n'
+                  b'</metadata>\n')
+    root = untldoc.untlxml2py(xml)
+    assert isinstance(root, us.UNTLElement)
+    assert root.tag == 'metadata'
+    assert root.children[0].tag == 'title'
+
+
+def test_untlxml2py_non_UNTL_tag_raises_exception():
+    xml = BytesIO(b'<?xml version="1.0" encoding="UTF-8"?>\n'
+                  b'<metadata>\n'
+                  b'  <dog>Bezos</dog>\n'
+                  b'</metadata>\n')
+    with pytest.raises(untldoc.PyuntlException) as err:
+        untldoc.untlxml2py(xml)
+    assert 'Element "dog" not in UNTL dispatch.' == err.value.args[0]
+
+
+def test_untlxml2pydict():
+    xml = BytesIO(UNTL_STRING.encode('utf-8'))
+    untl_dict = untldoc.untlxml2pydict(xml)
+    assert untl_dict == UNTL_DICTIONARY
+
+
+def test_untlpydict2xml(tmpdir):
+    xml_file = os.path.join(tmpdir, 'untl.xml')
+    returned_value = untldoc.untlpydict2xml(xml_file, UNTL_DICTIONARY)
+    # untlpydict2xml writes an XML file and returns None.
+    assert returned_value is None
+    with open(xml_file) as xml_f:
+        assert xml_f.read() == UNTL_STRING
+
+
+def test_untlpydict2xmlstring():
+    xml_string = untldoc.untlpydict2xmlstring(UNTL_DICTIONARY)
+    assert xml_string == UNTL_STRING.encode('utf-8')
+
+
+def test_untldict2py():
+    root = untldoc.untldict2py(UNTL_DICTIONARY)
+    assert isinstance(root, us.UNTLElement)
+    assert len(root.children) == 5
+    assert root.tag == 'metadata'
+    assert root.children[0].tag == 'title'
+    assert root.children[0].content == 'Tres Actos'
+    assert root.children[0].qualifier == 'officialtitle'
+    assert root.children[1].tag == 'creator'
+    assert root.children[1].qualifier == 'aut'
+    assert root.children[1].children[0].tag == 'name'
+    assert root.children[1].children[0].content == 'Last, Furston, 1807-1865.'
+    assert root.children[2].tag == 'publisher'
+    assert root.children[2].children[0].tag == 'name'
+    assert root.children[2].children[0].content == 'Fake Publishing'
+    assert root.children[3].tag == 'collection'
+    assert root.children[3].content == 'UNT'
+    assert root.children[4].tag == 'date'
+    assert root.children[4].content == '1944'
+
+
+def test_untldict2py_dict_includes_qualifier_only_element():
+    # Not sure if there are ever elements with no content and no children
+    # in practice, but the code handles that scenario.
+    untl_dict = deepcopy(UNTL_DICTIONARY)
+    untl_dict['date'] = [{'qualifier': 'creation'}]
+    root = untldoc.untldict2py(untl_dict)
+    assert isinstance(root, us.UNTLElement)
+    assert root.children[4].tag == 'date'
+    assert root.children[4].qualifier == 'creation'
+
+
+def test_post2pydict():
+    post_dict = {'creator-name': ['Eathing, Sai N.'],
+                 'relation-content': [''],
+                 'subject-qualifier': ['AAT', 'AAT'],
+                 'publisher-name': ['UNT Art'],
+                 'creator-role': ['art'],
+                 'title-content': ['Untitled 2000.'],
+                 'description-qualifier': ['physical', 'content'],
+                 'relation-qualifier': [''],
+                 'description-content': ['oil on canvas ; 12 x 6 in.',
+                                         'Painting of cookies.'],
+                 'publish': ['Publish'],
+                 'creator-info': ['UNT'],
+                 'collection-content': ['UNTCVA', 'UNTSW'],
+                 'subject-content': ['paintings (visual works)',
+                                     'works of art'],
+                 'creator-type': ['per'],
+                 'meta-qualifier': ['meta-id', 'system'],
+                 'csrfmiddlewaretoken': ['blahblahblahblah'],
+                 'meta-content': ['metatest1', 'DC'],
+                 'title-qualifier': ['officialtitle']}
+    ignore_list = ['publish', 'csrfmiddlewaretoken']
+    element_dict = untldoc.post2pydict(post_dict, ignore_list)
+    # publish and csrfmiddlewaretoken are not in the resulting dict.
+    assert element_dict == {'creator': [{'qualifier': 'art',
+                                         'content': {'name': 'Eathing, Sai N.',
+                                                     'info': 'UNT',
+                                                     'type': 'per'}}],
+                            'subject': [{'qualifier': 'AAT',
+                                         'content': 'paintings (visual works)'},
+                                        {'qualifier': 'AAT',
+                                         'content': 'works of art'}],
+                            'publisher': [{'content': {'name': 'UNT Art'}}],
+                            'title': [{'qualifier': 'officialtitle',
+                                       'content': 'Untitled 2000.'}],
+                            'description': [{'qualifier': 'physical',
+                                             'content': 'oil on canvas ; 12 x 6 in.'},
+                                            {'qualifier': 'content',
+                                             'content': 'Painting of cookies.'}],
+                            'collection': [{'content': 'UNTCVA'},
+                                           {'content': 'UNTSW'}],
+                            'meta': [{'qualifier': 'meta-id',
+                                      'content': 'metatest1'},
+                                     {'qualifier': 'system',
+                                      'content': 'DC'}]}
+
+
+def test_post2pydict_PyuntlException():
+    post_dict = {'subject-qualifier': ['AAT', 'AAT'],
+                 'subject-content': ['paintings (visual works)']}
+    with pytest.raises(untldoc.PyuntlException) as err:
+        untldoc.post2pydict(post_dict, [])
+    assert 'Field values did not match up numerically for subject' == err.value.args[0]
+
+
+def test_untlpy2dcpy():
+    untl_dict = {'coverage': [{'content': '1943', 'qualifier': 'sDate'},
+                              {'content': '1944', 'qualifier': 'eDate'},
+                              {'content': 'United States - Texas', 'qualifier': 'placeName'}],
+                 'publisher': [{'content': {'name': 'UNT Press', 'location': 'Denton, Texas'}}],
+                 'creator': [{'content': {'type': 'org', 'name': 'UNT'}, 'qualifier': 'aut'}],
+                 'title': [{'content': 'UNT Book', 'qualifier': 'officialtitle'}],
+                 'collection': [{'content': 'UNT'}]}
+    untl_elements = untldoc.untldict2py(untl_dict)
+    root = untldoc.untlpy2dcpy(untl_elements)
+    assert isinstance(root, dc.DCElement)
+    assert len(root.children) == 5
+    assert root.tag == 'dc'
+    assert root.children[0].tag == 'coverage'
+    assert root.children[0].content == 'United States - Texas'
+    assert root.children[1].tag == 'publisher'
+    assert root.children[1].content == 'UNT Press'
+    assert root.children[2].tag == 'creator'
+    assert root.children[2].content == 'UNT'
+    assert root.children[3].tag == 'title'
+    assert root.children[3].content == 'UNT Book'
+    # Coverage sDate/eDate are combined and added at the end.
+    assert root.children[4].tag == 'coverage'
+    assert root.children[4].content == '1943-1944'
+
+
+def test_untlpy2dcpy_resolve_values_verbose_vocabularies():
+    verbose_vocab = {'languages': [{'url': 'http://example.com/languages/#spa',
+                                    'name': 'spa',
+                                    'label': 'Spanish'}]}
+    untl_dict = {'language': [{'content': 'spa'}]}
+    untl_elements = untldoc.untldict2py(untl_dict)
+    root = untldoc.untlpy2dcpy(untl_elements,
+                               resolve_values=True,
+                               verbose_vocabularies=verbose_vocab)
+    assert root.children[0].tag == 'language'
+    assert root.children[0].content == 'Spanish'
+
+
+@patch('pyuntl.untldoc.retrieve_vocab')
+def test_untlpy2dcpy_resolve_values_retrieve_vocab(mock_vocab):
+    mock_vocab.return_value = {'languages': [{'url': 'http://example.com/languages/#spa',
+                                              'name': 'spa',
+                                              'label': 'Spanish'}]}
+    untl_dict = {'language': [{'content': 'spa'}]}
+    untl_elements = untldoc.untldict2py(untl_dict)
+    root = untldoc.untlpy2dcpy(untl_elements,
+                               resolve_values=True)
+    assert root.children[0].tag == 'language'
+    assert root.children[0].content == 'Spanish'
+
+
+def test_untlpy2dcpy_add_permalink_and_ark():
+    untl_dict = {'title': [{'content': 'UNT Book', 'qualifier': 'officialtitle'}]}
+    untl_elements = untldoc.untldict2py(untl_dict)
+    root = untldoc.untlpy2dcpy(untl_elements,
+                               ark='ark:/67531/metatest1',
+                               domain_name='example.com',
+                               scheme='https')
+    assert root.children[0].tag == 'title'
+    assert root.children[1].tag == 'identifier'
+    assert root.children[1].content == 'https://example.com/ark:/67531/metatest1/'
+    assert root.children[2].tag == 'identifier'
+    assert root.children[2].content == 'ark: ark:/67531/metatest1'
+
+
+def test_untlpy2dcpy_only_sDate():
+    untl_dict = {'coverage': [{'content': '1943', 'qualifier': 'sDate'}]}
+    untl_elements = untldoc.untldict2py(untl_dict)
+    root = untldoc.untlpy2dcpy(untl_elements)
+    assert root.children[0].tag == 'coverage'
+    assert root.children[0].content == '1943'
+
+
+def test_untlpy2dcpy_only_eDate():
+    untl_dict = {'coverage': [{'content': '1955', 'qualifier': 'eDate'}]}
+    untl_elements = untldoc.untldict2py(untl_dict)
+    root = untldoc.untlpy2dcpy(untl_elements)
+    assert root.children[0].tag == 'coverage'
+    assert root.children[0].content == '1955'
+
+
+def test_untlpy2highwirepy():
+    untl_elements = untldoc.untldict2py(UNTL_DICTIONARY)
+    highwire_list = untldoc.untlpy2highwirepy(untl_elements)
+    assert len(highwire_list) == 4
+    for element in highwire_list:
+        assert element.tag == 'meta'
+    assert highwire_list[0].qualifier == 'aut'
+    assert highwire_list[0].name == 'citation_author'
+    assert highwire_list[0].content == 'Last, Furston, 1807-1865.'
+    assert highwire_list[1].qualifier is None
+    assert highwire_list[1].name == 'citation_publisher'
+    assert highwire_list[1].content == 'Fake Publishing'
+    assert highwire_list[2].qualifier == 'creation'
+    assert highwire_list[2].name == 'citation_publication_date'
+    assert highwire_list[2].content == '1944'
+    assert highwire_list[3].qualifier == 'officialtitle'
+    assert highwire_list[3].name == 'citation_title'
+    assert highwire_list[3].content == 'Tres Actos'

--- a/tests/untldoc_test.py
+++ b/tests/untldoc_test.py
@@ -584,54 +584,6 @@ def test_add_empty_fields_allows_content_and_qualifier_has_children(mock_getattr
     assert untl_dict['subject'] == [{'content': {'fake child': ''}, 'qualifier': ''}]
 
 
-def test_add_empty_etd_ms_fields():
-    # Check all missing fields are added to etd_ms_dict.
-    # NOTE: pyuntl etd-ms stuff is currently unused and will be cut out
-    # in the near future.
-    metadata_dict = {'title': [{'qualifier': 'officialtitle',
-                                'content': 'A Good Dissertation'}],
-                     'degree': [{'content': {'grantor': 'UNT'}}],
-                     'contributor': [{'role': 'chair', 'content': 'Case, J.'}],
-                     'subject': [{'scheme': 'LC',
-                                  'content': 'dog'}],
-                     'type': [{'content': 'Thesis or Dissertation'}]}
-    etd_ms_dict = untldoc.add_empty_etd_ms_fields(metadata_dict)
-    assert etd_ms_dict == {'title': [{'qualifier': 'officialtitle',
-                           'content': 'A Good Dissertation'}],
-                           'degree': [{'content': {'grantor': 'UNT'}}],
-                           'contributor': [{'role': 'chair', 'content': 'Case, J.'}],
-                           'subject': [{'scheme': 'LC', 'content': 'dog'}],
-                           'type': [{'content': 'Thesis or Dissertation'}],
-                           'creator': [{'content': '', 'qualifier': ''}],
-                           'description': [{'content': {}, 'qualifier': ''}],
-                           'publisher': [{'content': '', 'qualifier': ''}],
-                           'date': [{'content': '', 'qualifier': ''}],
-                           'identifier': [{'content': '', 'qualifier': ''}],
-                           'language': [{'content': '', 'qualifier': ''}],
-                           'coverage': [{'content': '', 'qualifier': ''}],
-                           'rights': [{'content': '', 'qualifier': ''}]}
-
-
-@pytest.mark.xfail(reason=('`type` is in ETD_MS_ORDER but is not a key in'
-                           ' ETD_MS_CONVERSION_DISPATCH, so trying to fill'
-                           ' an empty field for `type` raises an exception.'
-                           ' Should this align with `resourceType`? If so,'
-                           ' the element tag may also be in question as that'
-                           ' is used to include ETD_MSType as an acceptable '
-                           ' child for the root "thesis" tag.'))
-def test_add_empty_etd_ms_fields_raises_PyuntlException():
-    metadata_dict = {'title': [{'qualifier': 'officialtitle',
-                                'content': 'A Good Dissertation'}],
-                     'degree': [{'content': {'grantor': 'UNT'}}],
-                     'contributor': [{'role': 'chair', 'content': 'Case, J.'}],
-                     'subject': [{'scheme': 'LC',
-                                  'content': 'dog'}]}
-    # Not having `type` in metadata_dict throws an exception.
-    with pytest.raises(untldoc.PyuntlException) as err:
-        untldoc.add_empty_etd_ms_fields(metadata_dict)
-    assert 'Could not add empty element field.' == err.value.args[0]
-
-
 def test_find_untl_errors():
     untl_dict = {'title': [{'content': 'Tres Actos'},
                            {'content': 'Three Acts',

--- a/tests/untldoc_test.py
+++ b/tests/untldoc_test.py
@@ -102,6 +102,15 @@ def test_untlxml2pydict():
     assert untl_dict == UNTL_DICTIONARY
 
 
+def test_untlpy2dict():
+    title = us.Title(qualifier='serialtitle', content='The Bronco')
+    elements = us.Metadata()
+    elements.add_child(title)
+    untl_dict = untldoc.untlpy2dict(elements)
+    assert untl_dict == {'title': [{'qualifier': 'serialtitle',
+                                    'content': 'The Bronco'}]}
+
+
 def test_untlpydict2xml(tmpdir):
     xml_file = os.path.join(tmpdir, 'untl.xml')
     returned_value = untldoc.untlpydict2xml(xml_file, UNTL_DICTIONARY)
@@ -253,6 +262,19 @@ def test_untlpy2dcpy_resolve_values_retrieve_vocab(mock_vocab):
                                resolve_values=True)
     assert root.children[0].tag == 'language'
     assert root.children[0].content == 'Spanish'
+
+
+def test_untlpy2dcpy_resolve_urls():
+    verbose_vocab = {'languages': [{'url': 'http://example.com/languages/#spa',
+                                    'name': 'spa',
+                                    'label': 'Spanish'}]}
+    untl_dict = {'language': [{'content': 'spa'}]}
+    untl_elements = untldoc.untldict2py(untl_dict)
+    root = untldoc.untlpy2dcpy(untl_elements,
+                               resolve_urls=True,
+                               verbose_vocabularies=verbose_vocab)
+    assert root.children[0].tag == 'language'
+    assert root.children[0].content == 'http://example.com/languages/#spa'
 
 
 def test_untlpy2dcpy_add_permalink_and_ark():


### PR DESCRIPTION
I have added unit tests for untldoc. After adding some test related to ETD-MS, Mark said we would cut out support for that later, but I left some of the tests there at the moment.I could get rid of em now instead of with the PR to remove ETD-MS later if you all prefer. This is for merging into the python2to3 branch, not master. ping @madhulika95b @somexpert 