### PR TITLE
Don't force a period at end of LCSH subjects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+x.x.x
+-----
+
+* Remove automatic addition of trailing period for LCSH. [#39](https://github.com/unt-libraries/pyuntl/issues/39)
 
 1.0.2
 -----
@@ -12,7 +16,7 @@ Change Log
 1.0.1
 -----
 
-* Fixed hardcoding of http scheme in permalinks by dc_structure.identifier_director. [#11] (https://github.com/unt-libraries/pyuntl/issues/11)
+* Fixed hardcoding of http scheme in permalinks by dc_structure.identifier_director. [#11](https://github.com/unt-libraries/pyuntl/issues/11)
 
 
 1.0.0

--- a/pyuntl/util.py
+++ b/pyuntl/util.py
@@ -7,12 +7,6 @@ def normalize_LCSH(subject):
     # rejoin after stripping parts.
     subject_parts = subject.strip().split('--')
     joined_subject = ' -- '.join([part.strip() for part in subject_parts])
-
-    # Check if there is punctuation at the end of the string,
-    # and if not, add a trailing period.
-    if re.search(r'[^a-zA-Z0-9]$', joined_subject) is None:
-        joined_subject = joined_subject + '.'
-
     return joined_subject
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -128,8 +128,8 @@ UNNORMALIZED_DICT = {
 # UNTL dict with proper normalization
 NORMALIZED_DICT = {
     'subject': [
-        {'content': 'Simmons College (Abilene, Tex.) -- Students -- Yearbooks.', 'qualifier': 'LCSH'},
-        {'content': 'Simmons University (Abilene, Tex.) -- Students -- Yearbooks.', 'qualifier': 'LCSH'},
+        {'content': 'Simmons College (Abilene, Tex.) -- Students -- Yearbooks', 'qualifier': 'LCSH'},
+        {'content': 'Simmons University (Abilene, Tex.) -- Students -- Yearbooks', 'qualifier': 'LCSH'},
         {'content': 'Hardin-Simmons University -- Students -- Yearbooks.', 'qualifier': 'LCSH'},
         {'content': 'World War, 1939-1945 -- Texas.', 'qualifier': 'LCSH'},
         {'content': 'World War, 1939-1945 -- Food supply -- United States.', 'qualifier': 'LCSH'},
@@ -148,7 +148,7 @@ UNNORMALIZED_LCSH = 'Guitar music--History and criticism'
 NORMALIZED_UNTLBS = 'Business, Economics and Finance - Journalism'
 
 # A normalized lcsh string
-NORMALIZED_LCSH = 'Guitar music -- History and criticism.'
+NORMALIZED_LCSH = 'Guitar music -- History and criticism'
 
 # Defined for testing post2pydict
 IGNORE_POST_LIST = [


### PR DESCRIPTION
This is to close #39 by removing the code that adds a period at the end of LCSH terms when there is not one there already. This is ready for review @madhulika95b @somexpert 