### PR TITLE
Add a function to convert untl json to python object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Change Log
 * Upgraded to Python 3. [#18](https://github.com/unt-libraries/pyuntl/issues/18)
 * Removed automatic addition of trailing period for LCSH. [#39](https://github.com/unt-libraries/pyuntl/issues/39)
 * Removed etd_ms support which is not used by pyuntl. [#29](https://github.com/unt-libraries/pyuntl/issues/29)
+* Added make_hidden, make_unhidden, is_hidden methods. [#37](https://github.com/unt-libraries/pyuntl/issues/37)
+* Added support for JSON serializations. [#38](https://github.com/unt-libraries/pyuntl/issues/38)
 
 
 1.0.2

--- a/pyuntl/untldoc.py
+++ b/pyuntl/untldoc.py
@@ -249,6 +249,12 @@ def generate_untl_json(untl_elements, json_indent=4):
     return json.dumps(untl_dict, sort_keys=True, indent=json_indent)
 
 
+def untljson2py(untl_json):
+    """Convert UNTL JSON into a Python object."""
+    untl_dict = json.loads(untl_json)
+    return untldict2py(untl_dict)
+
+
 def untlpy2dcpy(untl_elements, **kwargs):
     """Convert the UNTL elements structure into a DC structure.
 

--- a/tests/untldoc_test.py
+++ b/tests/untldoc_test.py
@@ -133,6 +133,14 @@ def test_generate_untl_json(input_indent, json_output):
     assert untl_json == json_output
 
 
+def test_untljson2py():
+    untl_py = untldoc.untljson2py(
+        '{"title": [{"content": "The Bronco", "qualifier": "serialtitle"}]}')
+    assert untl_py.children[0].tag == 'title'
+    assert untl_py.children[0].content == 'The Bronco'
+    assert untl_py.children[0].qualifier == 'serialtitle'
+
+
 def test_untlpydict2xml(tmpdir):
     xml_file = os.path.join(tmpdir, 'untl.xml')
     returned_value = untldoc.untlpydict2xml(xml_file, UNTL_DICTIONARY)

--- a/tests/untldoc_test.py
+++ b/tests/untldoc_test.py
@@ -139,6 +139,7 @@ def test_untljson2py():
     assert untl_py.children[0].tag == 'title'
     assert untl_py.children[0].content == 'The Bronco'
     assert untl_py.children[0].qualifier == 'serialtitle'
+    assert untl_py.tag == 'metadata'
 
 
 def test_untlpydict2xml(tmpdir):


### PR DESCRIPTION
@ldko @somexpert 
This PR adds a function to convert untl in json format back to python. It closes #45