### PR TITLE
No bytestring content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+2.X.X
+-----
+
+* Fixed issue of highwire elements storing escaped `content` as `bytes`. [#50](https://github.com/unt-libraries/pyuntl/pull/50)
+* Replaced deprecated `cgi.escape` with `html.escape`. [#50](https://github.com/unt-libraries/pyuntl/pull/50)
+
 2.0.0
 -----
 

--- a/pyuntl/highwire_structure.py
+++ b/pyuntl/highwire_structure.py
@@ -30,7 +30,7 @@ class HighwireElement(object):
             self.content = cgi.escape(
                 self.content,
                 1
-            ).encode('ascii', 'xmlcharrefreplace')
+            ).encode('ascii', 'xmlcharrefreplace').decode()
 
 
 class CitationTitle(HighwireElement):

--- a/pyuntl/highwire_structure.py
+++ b/pyuntl/highwire_structure.py
@@ -1,4 +1,4 @@
-import cgi
+import html
 import datetime
 
 from pyuntl import (CREATION_DATE_REGEX, CREATION_MONTH_REGEX,
@@ -27,7 +27,7 @@ class HighwireElement(object):
         escape = kwargs.get('escape', False)
         # Escape the content if needed.
         if escape and self.content:
-            self.content = cgi.escape(
+            self.content = html.escape(
                 self.content,
                 1
             ).encode('ascii', 'xmlcharrefreplace').decode()

--- a/tests/highwire_test.py
+++ b/tests/highwire_test.py
@@ -98,6 +98,13 @@ class TestHighwire(unittest.TestCase):
         highwire_text = generate_highwire_text(highwire_elements)
         self.assertEqual(highwire_text, HIGHWIRE_TEXT)
 
+    def testTextEscape(self):
+        """Test highwire elements are converted to ANVL text."""
+        untlpy = untldict2py(UNTL_DICT)
+        highwire_elements = untlpy2highwirepy(untlpy, escape=True)
+        highwire_text = generate_highwire_text(highwire_elements)
+        self.assertEqual(highwire_text, HIGHWIRE_TEXT)
+
     def testUNTL2HIGHWIRE(self):
         """Test conversion from UNTL to Highwire."""
         untlpy = untldict2py(UNTL_DICT)

--- a/tests/highwire_test.py
+++ b/tests/highwire_test.py
@@ -99,7 +99,7 @@ class TestHighwire(unittest.TestCase):
         self.assertEqual(highwire_text, HIGHWIRE_TEXT)
 
     def testTextEscape(self):
-        """Test highwire elements are converted to ANVL text."""
+        """Test highwire elements are converted to ANVL text when escaped."""
         small_untl_dict = {'title': [{'content': 'Clifford & Lassie',
                                       'qualifier': 'officialtitle'}],
                            'meta': [{'content': 'ark:/67531/metapth38622',

--- a/tests/highwire_test.py
+++ b/tests/highwire_test.py
@@ -100,10 +100,18 @@ class TestHighwire(unittest.TestCase):
 
     def testTextEscape(self):
         """Test highwire elements are converted to ANVL text."""
-        untlpy = untldict2py(UNTL_DICT)
+        small_untl_dict = {'title': [{'content': 'Clifford & Lassie',
+                                      'qualifier': 'officialtitle'}],
+                           'meta': [{'content': 'ark:/67531/metapth38622',
+                                     'qualifier': 'ark'},
+                                    {'content': '2008-06-29, 00:31:14',
+                                     'qualifier': 'metadataCreationDate'}]}
+        untlpy = untldict2py(small_untl_dict)
         highwire_elements = untlpy2highwirepy(untlpy, escape=True)
         highwire_text = generate_highwire_text(highwire_elements)
-        self.assertEqual(highwire_text, HIGHWIRE_TEXT)
+        expected = ('citation_title: Clifford &amp; Lassie\n'
+                    'citation_online_date: 06/29/2008')
+        self.assertEqual(highwire_text, expected)
 
     def testUNTL2HIGHWIRE(self):
         """Test conversion from UNTL to Highwire."""


### PR DESCRIPTION
Perhaps this was an issue since we upgraded to Python 3. I believe we should be returning a string for the highwire elements `content` even if we do `escape=True`. Before adding this `decode` change, if you added `escape=True` to the `testText` test, you would get back bytestrings:

```
    def testText(self):
        """Test highwire elements are converted to ANVL text."""
        untlpy = untldict2py(UNTL_DICT)
        highwire_elements = untlpy2highwirepy(untlpy, escape=True)
        highwire_text = generate_highwire_text(highwire_elements)
>       self.assertEqual(highwire_text, HIGHWIRE_TEXT)
E       AssertionError: "citation_title: b'The Bronco, Yearbook o[153 chars]008'" != 'citation_title: The Bronco, Yearbook of [141 chars]2008'
E       - citation_title: b'The Bronco, Yearbook of Hardin-Simmons University, 1944'
E       ?                 --                                                       -
E       + citation_title: The Bronco, Yearbook of Hardin-Simmons University, 1944
E       - citation_publisher: b'Hardin-Simmons University'
E       ?                     --                         -
E       + citation_publisher: Hardin-Simmons University
E       - citation_publication_date: b'1944'
E       ?                            --    -
E       + citation_publication_date: 1944
E       - citation_online_date: b'06/29/2008'?                       --          -
E       + citation_online_date: 06/29/2008
```

Additionally, in looking at this code, I noticed that `cgi.escape` was deprecated, so updated for that.

