### PR TITLE
change eDate & sDate to not be editable

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,4 +76,6 @@ Brandon Fredericks
 
 [Gio Gottardi](https://github.com/somexpert)  
 
+[Gracie Flores-Hays](https://github.com/gracieflores)
+
 If you have questions about the project feel free to contact Mark Phillips at mark.phillips@unt.edu.

--- a/pyuntl/form_logic.py
+++ b/pyuntl/form_logic.py
@@ -623,6 +623,9 @@ class Coverage(FormElement):
             self.vocabularies,
             self.qualifier_vocab
         )
+        if self.untl_object.qualifier == 'eDate' or self.untl_object.qualifier == 'sDate':
+            self.editable = False
+            self.editable_qualifiers = False
 
 
 class ResourceType(FormElement):


### PR DESCRIPTION
This change plus a small change to one edit template will close #53. The change here makes these qualifiers disabled for editing in the edit form.